### PR TITLE
Replace deprecated parameter name 

### DIFF
--- a/cauldron/cli/server/routes/display.py
+++ b/cauldron/cli/server/routes/display.py
@@ -24,5 +24,5 @@ def view(route: str):
     return flask.send_file(
         path,
         mimetype=mimetypes.guess_type(path)[0],
-        cache_timeout=-1
+        max_age=-1
     )

--- a/cauldron/ui/routes/apps/__init__.py
+++ b/cauldron/ui/routes/apps/__init__.py
@@ -34,5 +34,5 @@ def view(route: str):
     return flask.send_file(
         path,
         mimetype=mimetypes.guess_type(path)[0],
-        cache_timeout=-1
+        max_age=-1
     )

--- a/cauldron/ui/routes/notebooks/__init__.py
+++ b/cauldron/ui/routes/notebooks/__init__.py
@@ -64,7 +64,7 @@ def notebook(route: str):
             return flask.send_file(
                 local_asset_path,
                 mimetype=mimetypes.guess_type(local_asset_path)[0],
-                cache_timeout=-1
+                max_age=-1
             )
 
     if is_remote:
@@ -82,5 +82,5 @@ def notebook(route: str):
     return flask.send_file(
         path,
         mimetype=mimetypes.guess_type(path)[0],
-        cache_timeout=-1
+        max_age=-1
     )

--- a/cauldron/ui/routes/viewers/__init__.py
+++ b/cauldron/ui/routes/viewers/__init__.py
@@ -25,7 +25,7 @@ def view(route: str):
     return flask.send_file(
         path,
         mimetype=mimetypes.guess_type(path)[0],
-        cache_timeout=-1
+        max_age=-1
     )
 
 
@@ -42,5 +42,5 @@ def cache(route: str):
     return flask.send_file(
         path,
         mimetype=mimetypes.guess_type(path)[0],
-        cache_timeout=-1
+        max_age=-1
     )


### PR DESCRIPTION
Updated the flask.send_file cache_timeout parameter name to max_age. The old name is deprecated as of flask 2.2.0.

